### PR TITLE
Add continuous integration support

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -1,0 +1,16 @@
+name: Build Docker container
+
+on: [push]
+
+jobs:
+  build:
+    runs-on: ubuntu-latest  # has Docker pre-installed
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Install virtualenv
+        run: pip3 install virtualenv
+      - name: Install OpenSSL
+        run: sudo apt-get install openssl
+      - name: Run build
+        run: export COMPOSE_INTERACTIVE_NO_CLI=1; ./setup node rest

--- a/setup
+++ b/setup
@@ -128,7 +128,7 @@ if [[ $BTK_NODE == 1 ]]; then
 	sleep 5
 
 	# Generate some blocks
-	docker-compose exec bitcoind-regtest bitcoin-cli generate 210
+	docker-compose exec -T bitcoind-regtest bitcoin-cli generate 210
 
 	# Stop the server(s)
 	docker-compose stop 
@@ -243,9 +243,9 @@ if [[ $BTK_WALLET == 1 ]]; then
 		sleep 5
 
 		# Generate some blocks, and get their hashes/merkle roots
-		docker-compose exec bitcoind-regtest bitcoin-cli getblock 0 > ./Electron-Cash-SLP/genesis.txt
-		docker-compose exec bitcoind-regtest bitcoin-cli getblock 150 > ./Electron-Cash-SLP/fork.txt
-		docker-compose exec bitcoind-regtest bitcoin-cli getblock 200 > ./Electron-Cash-SLP/verification.txt
+		docker-compose exec -T bitcoind-regtest bitcoin-cli getblock 0 > ./Electron-Cash-SLP/genesis.txt
+		docker-compose exec -T bitcoind-regtest bitcoin-cli getblock 150 > ./Electron-Cash-SLP/fork.txt
+		docker-compose exec -T bitcoind-regtest bitcoin-cli getblock 200 > ./Electron-Cash-SLP/verification.txt
 
 		# Push hashes into environmental variables
 		cd ./Electron-Cash-SLP


### PR DESCRIPTION
This adds CI support using GitHub actions.  
Containers are built on every push to any branch. I omitted electron-cash for now (`./setup node rest` is run).